### PR TITLE
Report Memory size for info command

### DIFF
--- a/R4Ghidra/src/main/java/r4ghidra/repl/handlers/R2InfoCommandHandler.java
+++ b/R4Ghidra/src/main/java/r4ghidra/repl/handlers/R2InfoCommandHandler.java
@@ -159,7 +159,7 @@ private String formatInfoText(Program program, String arch, String bits, String 
 	try {
 	// Add program size
 	sb.append("size ")
-		.append(program.getMaxAddress().subtract(program.getMinAddress()) + 1)
+		.append(program.getMemory().getSize()) // getMinAddress and getMaxAddress can point to different AddressSpaces!
 		.append("\n");
 	} catch (Exception e) {
 	sb.append("# " + e.toString());


### PR DESCRIPTION
Since getMaxAddress() and getMinAddress() can point to different address spaces, the previous calculation could result in an exception. This change will just report the size of the Memory object as calculated by Ghidra.
